### PR TITLE
checkboxのlabelを段落ちしないように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterworks/yomogi-ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "author": "Tsukuni <tamkchi.fugu@gmail.com>",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -29,11 +29,15 @@ const Container = styled.div`
 `;
 
 const Label = styled.label<{ theme: Theme }>`
-  min-height: 17px;
   position: relative;
   display: inline-block;
+  width: 100%;
+  min-height: 17px;
   margin: 0;
   padding-left: 25px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
   &:hover {
     cursor: pointer;
   }

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -77,6 +77,7 @@ const Input = styled.input<{ theme: Theme }>`
       border-right: ${({ theme }) => `2px solid ${theme.colors.white}`};
       border-bottom:  ${({ theme }) => `2px solid ${theme.colors.white}`};
       content: '';
+      box-sizing: content-box;
       display: block;
       height: 7px;
       left: 5px;


### PR DESCRIPTION
## 概要
- checkboxコンポーネント内のlabelに制限を加えた
→これにより、コンポーネント使用時labelが長くなった際、意図しない段落ちが発生しないようになった。
## 発生事象image
![スクリーンショット 2022-12-02 9 31 05](https://user-images.githubusercontent.com/40589834/205188433-81dbfd9c-734e-4bdd-9e43-2890452f9726.png)
